### PR TITLE
Update the community installation method section for the Arch Linux package

### DIFF
--- a/setup/community/index.html
+++ b/setup/community/index.html
@@ -1671,8 +1671,8 @@ using the button below. This will run the official Docker image from <a href="ht
 <p><a href="https://www.pikapods.com/pods?run=hedgedoc"><img alt="Run on PikaPods" src="https://www.pikapods.com/static/run-button.svg" /></a></p>
 <h2 id="distribution-packages">Distribution Packages<a class="headerlink" href="#distribution-packages" title="Permanent link">&para;</a></h2>
 <h3 id="arch-linux">Arch Linux<a class="headerlink" href="#arch-linux" title="Permanent link">&para;</a></h3>
-<p>HedgeDoc is available in the Arch Linux <em>community</em> repository.</p>
-<p><a href="https://archlinux.org/packages/community/any/hedgedoc/">Link to the package</a></p>
+<p>HedgeDoc is available in the Arch Linux <em>extra</em> repository.</p>
+<p><a href="https://archlinux.org/packages/extra/any/hedgedoc/">Link to the package</a></p>
 <h3 id="freebsd">FreeBSD<a class="headerlink" href="#freebsd" title="Permanent link">&para;</a></h3>
 <p>HedgeDoc is available in the FreeBSD <em>ports</em> repository. After installation, customise your <code>config.json</code> file, referring to the official HedgeDoc documentation.</p>
 <p><a href="https://freshports.org/www/hedgedoc">Ports Repository</a></p>


### PR DESCRIPTION
The Arch Linux [community] repository has been merged into the [extra] repository [some time ago](https://archlinux.org/news/git-migration-completed/) and thus doesn't exists anymore.